### PR TITLE
Disable dll Trimming

### DIFF
--- a/.github/workflows/gh-page-deploy.yml
+++ b/.github/workflows/gh-page-deploy.yml
@@ -30,11 +30,6 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.x'
-    - name: Cache Blazor Build Output
-      uses: actions/cache@v3
-      with:
-        path: src/Draco.Editor.Web/build/
-        key: blazor # Yes the key is constant.
     - name: Run tests
       run: dotnet test ./src
     - name: Publish with dotnet

--- a/src/Draco.Editor.Web/Draco.Editor.Web.csproj
+++ b/src/Draco.Editor.Web/Draco.Editor.Web.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
+    <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Compiled code were targeting trimmed DLLs and failed to run because of that.  

This is a temporary fix.