### PR TITLE
Move the compiler toolchain in it's own webworker.

### DIFF
--- a/src/Draco.Editor.Web/Draco.Editor.Web.csproj
+++ b/src/Draco.Editor.Web/Draco.Editor.Web.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <PublishTrimmed>false</PublishTrimmed>
     <LangVersion>11</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +17,7 @@
     <PackageReference Include="Microsoft.JSInterop" Version="8.0.0-alpha.1.22567.5" />
   </ItemGroup>
 
-  <Target Name="JSSetup" BeforeTargets="BeforeBuild">
+  <Target Name="JSSetup" AfterTargets="AfterBuild">
     <Exec Command="npm install" WorkingDirectory="app"></Exec>
     <Exec Condition="'$(Configuration)' == 'Debug'" Command="npm run build-debug" WorkingDirectory="app"></Exec>
     <Exec Condition="'$(Configuration)' == 'Release'" Command="npm run build-release" WorkingDirectory="app"></Exec>

--- a/src/Draco.Editor.Web/Interop.cs
+++ b/src/Draco.Editor.Web/Interop.cs
@@ -1,0 +1,14 @@
+using System.Runtime.InteropServices.JavaScript;
+
+namespace Draco.Editor.Web;
+
+public static partial class Interop
+{
+    [JSImport("Interop.sendMessage", "worker.js")]
+    public static partial void SendMessage(string type, string message);
+
+    [JSExport]
+    public static void OnMessage(string type, string message) => Messages?.Invoke(null, (type, message));
+
+    public static event EventHandler<(string type, string message)>? Messages;
+}

--- a/src/Draco.Editor.Web/OnInit.cs
+++ b/src/Draco.Editor.Web/OnInit.cs
@@ -1,6 +1,6 @@
 namespace Draco.Editor.Web;
 
-public class OnInit
+public sealed class OnInit
 {
     public string OutputType { get; set; } = null!;
     public string Code { get; set; } = null!;

--- a/src/Draco.Editor.Web/OnInit.cs
+++ b/src/Draco.Editor.Web/OnInit.cs
@@ -1,0 +1,7 @@
+namespace Draco.Editor.Web;
+
+public class OnInit
+{
+    public string OutputType { get; set; } = null!;
+    public string Code { get; set; } = null!;
+}

--- a/src/Draco.Editor.Web/Program.cs
+++ b/src/Draco.Editor.Web/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.JSInterop;
 using Draco.Compiler.Api;
 using Draco.Compiler.Api.Syntax;
 using System.Text.Json;
+using ICSharpCode.Decompiler.IL;
 
 namespace Draco.Editor.Web;
 
@@ -28,11 +29,11 @@ public partial class Program
             await ProcessUserInput();
             return;
         case "OnOutputTypeChange":
-            selectedOutputType = message.payload;
+            selectedOutputType = JsonSerializer.Deserialize<string>(message.payload)!;
             await ProcessUserInput();
             return;
         case "CodeChange":
-            code = message.payload;
+            code = JsonSerializer.Deserialize<string>(message.payload)!;
             await ProcessUserInput();
             return;
         default:
@@ -76,7 +77,7 @@ public partial class Program
                 DisplayCompiledIL(compilation);
                 break;
             default:
-                throw new InvalidOperationException("Invalid switch case.");
+                throw new InvalidOperationException($"Invalid switch case: {selectedOutputType}.");
             }
         }
         catch (Exception e)
@@ -159,7 +160,6 @@ public partial class Program
     /// <returns></returns>
     private static void SetOutputText(string text)
     {
-        Console.WriteLine("Calling setOutput text with:" + text);
         Interop.SendMessage("setOutputText", text);
     }
 

--- a/src/Draco.Editor.Web/SourceGenerationContext.cs
+++ b/src/Draco.Editor.Web/SourceGenerationContext.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Draco.Editor.Web;
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(OnInit))]
+public partial class SourceGenerationContext : JsonSerializerContext
+{
+}

--- a/src/Draco.Editor.Web/app/build.js
+++ b/src/Draco.Editor.Web/app/build.js
@@ -7,11 +7,50 @@ import { createThemeBasedLogo as getFavicon } from './favicon-downloader.js';
 import { Octokit } from '@octokit/rest';
 import JSON5 from 'json5';
 import YAML from 'yaml';
-import { convertTheme } from "./theme-converter.js";
+import { defineConfig, build as viteBuild } from 'vite';
+import { convertTheme } from './theme-converter.js';
 // This file manage the build process of the webapp.
 
+const distDir = '../wwwroot';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const outDir = path.join(__dirname, distDir);
+const binFolder = process.argv[2];
+
+async function dotnetjsBuild() {
+    await viteBuild(defineConfig({ // Yes, I'm using another bundler, because this one bundle correctly dotnet.js to CJS...
+        build: {
+            lib: {
+                // Could also be a dictionary or array of multiple entry points
+                entry: path.resolve(binFolder, 'dotnet.js'),
+                name: 'dotnet',
+                fileName: 'dotnet',
+                formats: ['umd']
+            },
+            rollupOptions: {
+                // make sure to externalize deps that shouldn't be bundled
+                // into your library
+                external: ['dotnet.wasm'],
+                output: {
+                    esModule: false,
+                    format: 'cjs',
+                    compact: true
+                }
+            },
+            outDir: outDir
+        }
+    }));
+    // Problem #1: ASP.NET DevServer doesn't send the correct MIME Type on cjs files.
+    // Problem #2: I lost 30 mins trying to configure rollup to output `dotnet.js` instead of `dotnet.cjs` without success.
+    // So I rename the file by hand instead...
+    fs.renameSync(path.join(outDir, 'dotnet.umd.cjs'), path.join(outDir, 'dotnet.js'));
+
+    fs.copyFileSync(path.join(binFolder, 'dotnet.wasm'), path.join(outDir, 'dotnet.wasm'));
+}
+
+await dotnetjsBuild();
+
+
 
 
 // this is a plugin to handle wasm file. We handle it like it was a binary file.
@@ -29,11 +68,10 @@ const workerEntryPoints = [
     'vs/editor/editor.worker.js'
 ];
 
-const distDir = process.argv[2];
-const outDir = path.join(__dirname, distDir);
+
 
 // Bundle monaco editor workers.
-build({
+await build({
     entryPoints: workerEntryPoints.map((entry) => `node_modules/monaco-editor/esm/${entry}`),
     bundle: true,
     format: 'iife',
@@ -41,17 +79,27 @@ build({
 });
 
 // Bundle our app.
-build({
+await build({
     entryPoints: ['ts/app.ts', 'css/app.css'],
     bundle: true,
-    format: 'esm', // We want ESM to use import in Blazor.
+    format: 'esm',
     outdir: outDir,
     loader: {
         '.ttf': 'file'
     },
     inject: ['ts/process.ts'],
-    plugins: [wasmPlugin]
+    plugins: [wasmPlugin],
+    external: ['dotnet.wasm']
 });
+
+// Bundle the worker.
+await build({
+    entryPoints: ['ts/worker.ts'],
+    bundle: true,
+    format: 'cjs',
+    outfile: path.join(outDir,'worker.js'),
+});
+
 
 if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
 fs.copyFileSync('index.html', path.join(outDir, 'index.html'),); // Copy index.html to wwwroot.

--- a/src/Draco.Editor.Web/app/build.js
+++ b/src/Draco.Editor.Web/app/build.js
@@ -50,9 +50,6 @@ async function dotnetjsBuild() {
 
 await dotnetjsBuild();
 
-
-
-
 // this is a plugin to handle wasm file. We handle it like it was a binary file.
 let wasmPlugin = {
     name: 'wasm',
@@ -67,8 +64,6 @@ let wasmPlugin = {
 const workerEntryPoints = [
     'vs/editor/editor.worker.js'
 ];
-
-
 
 // Bundle monaco editor workers.
 await build({
@@ -97,9 +92,8 @@ await build({
     entryPoints: ['ts/worker.ts'],
     bundle: true,
     format: 'cjs',
-    outfile: path.join(outDir,'worker.js'),
+    outfile: path.join(outDir, 'worker.js'),
 });
-
 
 if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
 fs.copyFileSync('index.html', path.join(outDir, 'index.html'),); // Copy index.html to wwwroot.

--- a/src/Draco.Editor.Web/app/index.html
+++ b/src/Draco.Editor.Web/app/index.html
@@ -25,7 +25,6 @@
         <div id="draco-editor"></div>
         <div id="output-viewer"> </div>
     </div>
-    <script src="_framework/blazor.webassembly.js" type="module" autostart="false"></script>
     <script src="ts/app.js" type="module"></script>
 </body>
 

--- a/src/Draco.Editor.Web/app/package-lock.json
+++ b/src/Draco.Editor.Web/app/package-lock.json
@@ -18,20 +18,25 @@
       },
       "devDependencies": {
         "@octokit/rest": "^19.0.5",
-        "@types/blazor__javascript-interop": "^3.1.2",
         "@types/node": "^18.11.9",
         "@types/pako": "^2.0.0",
         "@typescript-eslint/eslint-plugin": "^5.42.1",
         "@typescript-eslint/parser": "^5.42.1",
         "esbuild": "^0.15.13",
-        "esbuild-plugin-wat": "^0.2.7",
         "eslint": "^8.27.0",
         "json5": "^2.2.1",
         "node-ts": "^5.1.2",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.4",
+        "vite": "^3.2.0",
         "yaml": "^2.1.3"
       }
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "extraneous": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -400,12 +405,6 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
-    "node_modules/@types/blazor__javascript-interop": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/blazor__javascript-interop/-/blazor__javascript-interop-3.1.2.tgz",
-      "integrity": "sha512-W9R+VZ8AFKoXBCCyccRLKrMmCVrridLShgGf4By+1xqfWFprERzqu0DinKn47P0q6x8G/3HCvgYRP2a/y8AjxA==",
-      "dev": true
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -716,147 +715,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@webassemblyjs/ast": {
-      "version": "1.11.1",
-      "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-ast.tgz",
-      "integrity": "sha512-cY3aYc1FhZdiE9wUn474Kw+l288fmWZsrfLv8fR8/5q3rcUlYO+YoHewwPDV3L0sJBh48qCKORA/+PqQG7rDYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/helper-numbers": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-numbers.tgz",
-        "@webassemblyjs/helper-wasm-bytecode": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-wasm-bytecode.tgz"
-      }
-    },
-    "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.1",
-      "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-floating-point-hex-parser.tgz",
-      "integrity": "sha512-z+6ExkIgehxOYG/AgXzBrkCJXAA9FmylpeE/85lYPounBo/eylW6NsvOkVcvzL5KETdKdxSbP0dCwxzAA5TFYA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.11.1",
-      "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
-      "integrity": "sha512-s47oO2lTrZ4YetGYyu7P4ueUZ3Zl+UfzGySLUFkPlxrV8amp4ySeiG0cS4zE54WYJ5ajG8x+kPcj+wmJmqjc8A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/helper-code-frame": {
-      "version": "1.11.1",
-      "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-code-frame.tgz",
-      "integrity": "sha512-aF2xsJ/LYz6ld4+zNDJ8AsynC3g0UiP1/u+HExz6bPFq55VP7RL0/v22tixuzlfpVkOOrtapt9DL+uFJYSZoZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/wast-printer": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-wast-printer.tgz"
-      }
-    },
-    "node_modules/@webassemblyjs/helper-fsm": {
-      "version": "1.11.1",
-      "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-fsm.tgz",
-      "integrity": "sha512-7GIVVj64wX4PZxQ89p/GjcMgMQW68DikfzSg18neCJvHa6d8+M0G1oUeeu2L+VfKf3DH9qfGwDjjwHiyMeATAg==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.11.1",
-      "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-numbers.tgz",
-      "integrity": "sha512-G9XJ1H90Po0cIEUgi3JlEg5x35k1WTjIhT1OSa6dWjP6Gu4H3unqUkdbnBHmgrdBx/TKuhm0fHarsIyGsneMSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-floating-point-hex-parser.tgz",
-        "@webassemblyjs/helper-api-error": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.1",
-      "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-wasm-bytecode.tgz",
-      "integrity": "sha512-XPAPtrVginHTCjk4taKHVZq7A1mC8zcLrNS3PTWzR84IX1RUdVI7XpAulr6F6bzBHrpRfm8JDq9PhLxCqEjgvA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.11.1",
-      "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ieee754.tgz",
-      "integrity": "sha512-xhKvCB2yysf6hg7LE52/0Q4DK9ydWkZIPwhQuGBtatSjwxU1oFd7JxQe+oqd8bmrYEd/W86Cq1FfA81IOpKTqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "node_modules/@webassemblyjs/leb128": {
-      "version": "1.11.1",
-      "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-leb128.tgz",
-      "integrity": "sha512-eXvoK2Q3MG9IXIRmVncysJDk2y7ImoztWbbRE/UytbBAFkw/c2qxTVty3gX2YhoRjAvv9/ifBqVkBZ8uh4/KSg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/utf8": {
-      "version": "1.11.1",
-      "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-utf8.tgz",
-      "integrity": "sha512-K0M8V6g1+k4hSoP/XdPvAN2y7A2FYP5IThWUTRSif1KhbiggxF1jbiVoq7YLCucWA8MZs/f5p257KKqtSKXP1A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.11.1",
-      "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wasm-parser.tgz",
-      "integrity": "sha512-/jo3/7k69tIuWln/HaHKhTfm3f3zISDmCXKVFeGPc3XMPLr11EY0p3zPyHG1SKHkWETdG5LJIhMaD+CAlfk6qg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ast.tgz",
-        "@webassemblyjs/helper-api-error": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
-        "@webassemblyjs/helper-wasm-bytecode": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-wasm-bytecode.tgz",
-        "@webassemblyjs/ieee754": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ieee754.tgz",
-        "@webassemblyjs/leb128": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-leb128.tgz",
-        "@webassemblyjs/utf8": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-utf8.tgz"
-      }
-    },
-    "node_modules/@webassemblyjs/wast-parser": {
-      "version": "1.11.1",
-      "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wast-parser.tgz",
-      "integrity": "sha512-DVGZfBnzYbqyHuvAKGiDc8gw0s0MITY2zrsPGvtx2XpaNJ1tHaeNpyOHs+GvN6/k7VsuEmNqrIzTpl6apw1oSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ast.tgz",
-        "@webassemblyjs/floating-point-hex-parser": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-floating-point-hex-parser.tgz",
-        "@webassemblyjs/helper-api-error": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
-        "@webassemblyjs/helper-code-frame": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-code-frame.tgz",
-        "@webassemblyjs/helper-fsm": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-fsm.tgz",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.11.1",
-      "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wast-printer.tgz",
-      "integrity": "sha512-WFuDIpmoSfU0Du2GA/UGluMJLgKWALsGPcvkDFg3GDgxdDyva1hIW+8K6frSbv/YTwo50gBhW5dw4OB7cr6T5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ast.tgz",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@xtuc/ieee754": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "dev": true
-    },
-    "node_modules/@xtuc/long": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "dev": true
-    },
     "node_modules/acorn": {
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
@@ -979,16 +837,6 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
-    "node_modules/binaryen": {
-      "version": "110.0.0",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-110.0.0.tgz",
-      "integrity": "sha512-b1rQFvnjNIfuW0UYSBgwLIrKD9PaG0iEzWXyoWLBFp/HRdvgD+7LGUnxG+/yKz1+tyiTdRm/lFRxsmYXaULIUg==",
-      "dev": true,
-      "bin": {
-        "wasm-opt": "bin/wasm-opt",
-        "wasm2js": "bin/wasm2js"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1075,12 +923,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "node_modules/concat-map": {
@@ -1170,12 +1012,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/es-module-lexer": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
-      "integrity": "sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==",
-      "dev": true
     },
     "node_modules/esbuild": {
       "version": "0.15.13",
@@ -1468,26 +1304,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-plugin-wat": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/esbuild-plugin-wat/-/esbuild-plugin-wat-0.2.7.tgz",
-      "integrity": "sha512-Hb2BJHezVrKDu3zY/gAKdLa5j3l8ybgi7UDgxFHwpxjMRqmMgceBa1FIQLZovfh5bhbl1u0n4MMnhRS0yM1BNg==",
-      "dev": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-ast.tgz",
-        "@webassemblyjs/wasm-parser": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wasm-parser.tgz",
-        "@webassemblyjs/wast-parser": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wast-parser.tgz",
-        "@webassemblyjs/wast-printer": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wast-printer.tgz",
-        "binaryen": "latest",
-        "find-cache-dir": "^3.3.1",
-        "minimist": "^1.2.5",
-        "parse-imports": "^1.1.0",
-        "wabt": "latest"
-      },
-      "bin": {
-        "watbundle": "bin/watbundle.js"
       }
     },
     "node_modules/esbuild-sunos-64": {
@@ -1915,36 +1731,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/find-cache-dir": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-      "dev": true,
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^3.0.2",
-        "pkg-dir": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
-      }
-    },
-    "node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -1981,6 +1767,26 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "node_modules/glob": {
@@ -2061,6 +1867,18 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2137,6 +1955,18 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    },
+    "node_modules/is-core-module": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2258,18 +2088,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2282,21 +2100,6 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-error": {
@@ -2339,15 +2142,6 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/monaco-editor": {
       "version": "0.34.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
@@ -2378,6 +2172,18 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2464,42 +2270,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/pako": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
@@ -2515,19 +2285,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/parse-imports": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parse-imports/-/parse-imports-1.1.0.tgz",
-      "integrity": "sha512-ov3Rc9e3wX9+BLR7nFx08+ThdLJfzi8ZXQrqZXfmuxdL+JCCN24m2uuBFBoaa/yyiZ9s8HjcHGDKSXJbKAyDQA==",
-      "dev": true,
-      "dependencies": {
-        "es-module-lexer": "0.4.1",
-        "slashes": "2.0.2"
-      },
-      "engines": {
-        "node": ">= 12.17"
       }
     },
     "node_modules/path": {
@@ -2566,6 +2323,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -2574,6 +2337,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -2587,16 +2356,28 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+    "node_modules/postcss": {
+      "version": "8.4.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
       "dependencies": {
-        "find-up": "^4.0.0"
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -2657,6 +2438,23 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2691,6 +2489,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2712,15 +2525,6 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/shebang-command": {
@@ -2753,11 +2557,14 @@
         "node": ">=8"
       }
     },
-    "node_modules/slashes": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/slashes/-/slashes-2.0.2.tgz",
-      "integrity": "sha512-68p+QkFAQQRetIUzNXAdktNJr8AYLxJukjBegYQz8F7VATsBJG621UYtY/vS2j9jerxdJ1k6Tc25K4DXEw1d5w==",
-      "dev": true
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -2793,6 +2600,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/text-table": {
@@ -2962,21 +2781,53 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
-    "node_modules/wabt": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/wabt/-/wabt-1.0.30.tgz",
-      "integrity": "sha512-qM1QnttJhjZ4vTSuXvder43yxgGhVffT/0wMc0SwYpboEW0/ENISpei/2kIDEMPrnNfTQ4GdvD7JIFV0IJPYog==",
+    "node_modules/vite": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.4.tgz",
+      "integrity": "sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==",
       "dev": true,
+      "dependencies": {
+        "esbuild": "^0.15.9",
+        "postcss": "^8.4.18",
+        "resolve": "^1.22.1",
+        "rollup": "^2.79.1"
+      },
       "bin": {
-        "wasm-decompile": "bin/wasm-decompile",
-        "wasm-interp": "bin/wasm-interp",
-        "wasm-objdump": "bin/wasm-objdump",
-        "wasm-opcodecnt": "bin/wasm-opcodecnt",
-        "wasm-strip": "bin/wasm-strip",
-        "wasm-validate": "bin/wasm-validate",
-        "wasm2c": "bin/wasm2c",
-        "wasm2wat": "bin/wasm2wat",
-        "wat2wasm": "bin/wat2wasm"
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
       }
     },
     "node_modules/webidl-conversions": {
@@ -3344,12 +3195,6 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
-    "@types/blazor__javascript-interop": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/blazor__javascript-interop/-/blazor__javascript-interop-3.1.2.tgz",
-      "integrity": "sha512-W9R+VZ8AFKoXBCCyccRLKrMmCVrridLShgGf4By+1xqfWFprERzqu0DinKn47P0q6x8G/3HCvgYRP2a/y8AjxA==",
-      "dev": true
-    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -3550,121 +3395,6 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
-    "@webassemblyjs/ast": {
-      "version": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-ast.tgz",
-      "integrity": "sha512-cY3aYc1FhZdiE9wUn474Kw+l288fmWZsrfLv8fR8/5q3rcUlYO+YoHewwPDV3L0sJBh48qCKORA/+PqQG7rDYA==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/helper-numbers": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-numbers.tgz",
-        "@webassemblyjs/helper-wasm-bytecode": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-wasm-bytecode.tgz"
-      }
-    },
-    "@webassemblyjs/floating-point-hex-parser": {
-      "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-floating-point-hex-parser.tgz",
-      "integrity": "sha512-z+6ExkIgehxOYG/AgXzBrkCJXAA9FmylpeE/85lYPounBo/eylW6NsvOkVcvzL5KETdKdxSbP0dCwxzAA5TFYA==",
-      "dev": true
-    },
-    "@webassemblyjs/helper-api-error": {
-      "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
-      "integrity": "sha512-s47oO2lTrZ4YetGYyu7P4ueUZ3Zl+UfzGySLUFkPlxrV8amp4ySeiG0cS4zE54WYJ5ajG8x+kPcj+wmJmqjc8A==",
-      "dev": true
-    },
-    "@webassemblyjs/helper-code-frame": {
-      "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-code-frame.tgz",
-      "integrity": "sha512-aF2xsJ/LYz6ld4+zNDJ8AsynC3g0UiP1/u+HExz6bPFq55VP7RL0/v22tixuzlfpVkOOrtapt9DL+uFJYSZoZQ==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/wast-printer": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-wast-printer.tgz"
-      }
-    },
-    "@webassemblyjs/helper-fsm": {
-      "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-fsm.tgz",
-      "integrity": "sha512-7GIVVj64wX4PZxQ89p/GjcMgMQW68DikfzSg18neCJvHa6d8+M0G1oUeeu2L+VfKf3DH9qfGwDjjwHiyMeATAg==",
-      "dev": true
-    },
-    "@webassemblyjs/helper-numbers": {
-      "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-numbers.tgz",
-      "integrity": "sha512-G9XJ1H90Po0cIEUgi3JlEg5x35k1WTjIhT1OSa6dWjP6Gu4H3unqUkdbnBHmgrdBx/TKuhm0fHarsIyGsneMSA==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/floating-point-hex-parser": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-floating-point-hex-parser.tgz",
-        "@webassemblyjs/helper-api-error": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-wasm-bytecode.tgz",
-      "integrity": "sha512-XPAPtrVginHTCjk4taKHVZq7A1mC8zcLrNS3PTWzR84IX1RUdVI7XpAulr6F6bzBHrpRfm8JDq9PhLxCqEjgvA==",
-      "dev": true
-    },
-    "@webassemblyjs/ieee754": {
-      "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ieee754.tgz",
-      "integrity": "sha512-xhKvCB2yysf6hg7LE52/0Q4DK9ydWkZIPwhQuGBtatSjwxU1oFd7JxQe+oqd8bmrYEd/W86Cq1FfA81IOpKTqA==",
-      "dev": true,
-      "requires": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "@webassemblyjs/leb128": {
-      "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-leb128.tgz",
-      "integrity": "sha512-eXvoK2Q3MG9IXIRmVncysJDk2y7ImoztWbbRE/UytbBAFkw/c2qxTVty3gX2YhoRjAvv9/ifBqVkBZ8uh4/KSg==",
-      "dev": true,
-      "requires": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@webassemblyjs/utf8": {
-      "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-utf8.tgz",
-      "integrity": "sha512-K0M8V6g1+k4hSoP/XdPvAN2y7A2FYP5IThWUTRSif1KhbiggxF1jbiVoq7YLCucWA8MZs/f5p257KKqtSKXP1A==",
-      "dev": true
-    },
-    "@webassemblyjs/wasm-parser": {
-      "version": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wasm-parser.tgz",
-      "integrity": "sha512-/jo3/7k69tIuWln/HaHKhTfm3f3zISDmCXKVFeGPc3XMPLr11EY0p3zPyHG1SKHkWETdG5LJIhMaD+CAlfk6qg==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ast.tgz",
-        "@webassemblyjs/helper-api-error": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
-        "@webassemblyjs/helper-wasm-bytecode": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-wasm-bytecode.tgz",
-        "@webassemblyjs/ieee754": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ieee754.tgz",
-        "@webassemblyjs/leb128": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-leb128.tgz",
-        "@webassemblyjs/utf8": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-utf8.tgz"
-      }
-    },
-    "@webassemblyjs/wast-parser": {
-      "version": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wast-parser.tgz",
-      "integrity": "sha512-DVGZfBnzYbqyHuvAKGiDc8gw0s0MITY2zrsPGvtx2XpaNJ1tHaeNpyOHs+GvN6/k7VsuEmNqrIzTpl6apw1oSQ==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ast.tgz",
-        "@webassemblyjs/floating-point-hex-parser": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-floating-point-hex-parser.tgz",
-        "@webassemblyjs/helper-api-error": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
-        "@webassemblyjs/helper-code-frame": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-code-frame.tgz",
-        "@webassemblyjs/helper-fsm": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-fsm.tgz",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@webassemblyjs/wast-printer": {
-      "version": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wast-printer.tgz",
-      "integrity": "sha512-WFuDIpmoSfU0Du2GA/UGluMJLgKWALsGPcvkDFg3GDgxdDyva1hIW+8K6frSbv/YTwo50gBhW5dw4OB7cr6T5Q==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ast.tgz",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@xtuc/ieee754": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "dev": true
-    },
-    "@xtuc/long": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "dev": true
-    },
     "acorn": {
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
@@ -3746,12 +3476,6 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
-    "binaryen": {
-      "version": "110.0.0",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-110.0.0.tgz",
-      "integrity": "sha512-b1rQFvnjNIfuW0UYSBgwLIrKD9PaG0iEzWXyoWLBFp/HRdvgD+7LGUnxG+/yKz1+tyiTdRm/lFRxsmYXaULIUg==",
-      "dev": true
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3809,12 +3533,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "concat-map": {
@@ -3884,12 +3602,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "es-module-lexer": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
-      "integrity": "sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==",
-      "dev": true
     },
     "esbuild": {
       "version": "0.15.13",
@@ -4032,23 +3744,6 @@
       "integrity": "sha512-nkuDlIjF/sfUhfx8SKq0+U+Fgx5K9JcPq1mUodnxI0x4kBdCv46rOGWbuJ6eof2n3wdoCLccOoJAbg9ba/bT2w==",
       "dev": true,
       "optional": true
-    },
-    "esbuild-plugin-wat": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/esbuild-plugin-wat/-/esbuild-plugin-wat-0.2.7.tgz",
-      "integrity": "sha512-Hb2BJHezVrKDu3zY/gAKdLa5j3l8ybgi7UDgxFHwpxjMRqmMgceBa1FIQLZovfh5bhbl1u0n4MMnhRS0yM1BNg==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-ast.tgz",
-        "@webassemblyjs/wasm-parser": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wasm-parser.tgz",
-        "@webassemblyjs/wast-parser": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wast-parser.tgz",
-        "@webassemblyjs/wast-printer": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wast-printer.tgz",
-        "binaryen": "latest",
-        "find-cache-dir": "^3.3.1",
-        "minimist": "^1.2.5",
-        "parse-imports": "^1.1.0",
-        "wabt": "latest"
-      }
     },
     "esbuild-sunos-64": {
       "version": "0.15.13",
@@ -4350,27 +4045,6 @@
         "to-regex-range": "^5.0.1"
       }
     },
-    "find-cache-dir": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-      "dev": true,
-      "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^3.0.2",
-        "pkg-dir": "^4.1.0"
-      }
-    },
-    "find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "requires": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      }
-    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -4401,6 +4075,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "glob": {
@@ -4460,6 +4147,15 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4507,6 +4203,15 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    },
+    "is-core-module": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -4599,15 +4304,6 @@
         "type-check": "~0.4.0"
       }
     },
-    "locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "requires": {
-        "p-locate": "^4.1.0"
-      }
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4620,15 +4316,6 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
         "yallist": "^3.0.2"
-      }
-    },
-    "make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "requires": {
-        "semver": "^6.0.0"
       }
     },
     "make-error": {
@@ -4662,12 +4349,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-      "dev": true
-    },
     "monaco-editor": {
       "version": "0.34.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
@@ -4691,6 +4372,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "dev": true
     },
     "natural-compare": {
@@ -4763,30 +4450,6 @@
         "word-wrap": "^1.2.3"
       }
     },
-    "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "requires": {
-        "p-try": "^2.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "requires": {
-        "p-limit": "^2.2.0"
-      }
-    },
-    "p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
-    },
     "pako": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
@@ -4799,16 +4462,6 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
-      }
-    },
-    "parse-imports": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parse-imports/-/parse-imports-1.1.0.tgz",
-      "integrity": "sha512-ov3Rc9e3wX9+BLR7nFx08+ThdLJfzi8ZXQrqZXfmuxdL+JCCN24m2uuBFBoaa/yyiZ9s8HjcHGDKSXJbKAyDQA==",
-      "dev": true,
-      "requires": {
-        "es-module-lexer": "0.4.1",
-        "slashes": "2.0.2"
       }
     },
     "path": {
@@ -4838,10 +4491,22 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
     "picomatch": {
@@ -4850,13 +4515,15 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
-    "pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+    "postcss": {
+      "version": "8.4.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
       "dev": true,
       "requires": {
-        "find-up": "^4.0.0"
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       }
     },
     "prelude-ls": {
@@ -4888,6 +4555,17 @@
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
+    "resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4909,6 +4587,15 @@
         "glob": "^7.1.3"
       }
     },
+    "rollup": {
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4917,12 +4604,6 @@
       "requires": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -4945,10 +4626,10 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
-    "slashes": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/slashes/-/slashes-2.0.2.tgz",
-      "integrity": "sha512-68p+QkFAQQRetIUzNXAdktNJr8AYLxJukjBegYQz8F7VATsBJG621UYtY/vS2j9jerxdJ1k6Tc25K4DXEw1d5w==",
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
     "strip-ansi": {
@@ -4974,6 +4655,12 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",
@@ -5094,11 +4781,18 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
-    "wabt": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/wabt/-/wabt-1.0.30.tgz",
-      "integrity": "sha512-qM1QnttJhjZ4vTSuXvder43yxgGhVffT/0wMc0SwYpboEW0/ENISpei/2kIDEMPrnNfTQ4GdvD7JIFV0IJPYog==",
-      "dev": true
+    "vite": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.4.tgz",
+      "integrity": "sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.15.9",
+        "fsevents": "~2.3.2",
+        "postcss": "^8.4.18",
+        "resolve": "^1.22.1",
+        "rollup": "^2.79.1"
+      }
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/src/Draco.Editor.Web/app/package.json
+++ b/src/Draco.Editor.Web/app/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "build-debug": "tsc -noEmit && node build.js ../wwwroot",
-    "build-release": "tsc -noEmit && node build.js ../wwwroot"
+    "build-debug": "tsc -noEmit && node build.js ../bin/Debug/net7.0",
+    "build-release": "tsc -noEmit && node build.js ../bin/Release/net7.0"
   },
   "dependencies": {
     "@octokit/auth-action": "^2.0.2",
@@ -18,18 +18,17 @@
   },
   "devDependencies": {
     "@octokit/rest": "^19.0.5",
-    "@types/blazor__javascript-interop": "^3.1.2",
     "@types/node": "^18.11.9",
     "@types/pako": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
     "esbuild": "^0.15.13",
-    "esbuild-plugin-wat": "^0.2.7",
     "eslint": "^8.27.0",
     "json5": "^2.2.1",
     "node-ts": "^5.1.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4",
+    "vite": "^3.2.0",
     "yaml": "^2.1.3"
   }
 }

--- a/src/Draco.Editor.Web/app/ts/app.ts
+++ b/src/Draco.Editor.Web/app/ts/app.ts
@@ -5,15 +5,12 @@ import { Registry } from 'monaco-textmate';
 import { wireTmGrammars } from 'monaco-editor-textmate'; // Library that allow running Textmates grammar in monaco.
 import grammarDefinition from '../../../Draco.SyntaxHighlighting/draco.tmLanguage.json';
 import { deflateRaw, inflateRaw } from 'pako';
+import { IWorkerMessage } from './workerMessage.js';
 
 // This file is run on page load.
 // This run before blazor load, and will tell blazor to start.
 
-declare global { // Blazor do not provide types, so we have our own to please typescript.
-    class Blazor {
-        static start(): Promise<void>;
-    }
-}
+const worker = new Worker('worker.js'); // first thing: we start the worker so it load in parallel.
 
 self.MonacoEnvironment = {
     // Web Workers need to start a new script, by url.
@@ -58,17 +55,7 @@ function updateHash() {
     const buffer = new Uint8Array(compressed.length + 1);
     buffer[0] = 1; // version, for future use.
     buffer.set(compressed, 1);
-    window.location.hash = fromBase64ToBase64URL(toBase64(buffer));
-}
-
-// We export this method so the C# runtime can call them.
-
-/**
- * Sets the text of the output monaco-editor.
- * @param text
- */
-export function setOutputText(text: string) {
-    outputEditor.getModel().setValue(text);
+    history.replaceState(undefined, undefined, '#' + fromBase64ToBase64URL(toBase64(buffer)));
 }
 
 // this is the element that allow to select the output type.
@@ -110,9 +97,11 @@ outputTypeSelector.onchange = () => {
         monaco.editor.setModelLanguage(outputEditor.getModel(), 'none');
         break;
     }
-
     // We relay the output type change to C#.
-    DotNet.invokeMethodAsync<void>('Draco.Editor.Web', 'OnOutputTypeChange', newVal);
+    worker.postMessage({
+        type: 'OnOutputTypeChange',
+        paylod: newVal
+    });
 };
 
 const dracoEditor = monaco.editor.create(document.getElementById('draco-editor'), {
@@ -123,7 +112,10 @@ const dracoEditor = monaco.editor.create(document.getElementById('draco-editor')
 
 dracoEditor.onDidChangeModelContent(() => {
     updateHash();
-    DotNet.invokeMethodAsync<void>('Draco.Editor.Web', 'CodeChange', dracoEditor.getModel().createSnapshot().read());
+    worker.postMessage({
+        type: 'CodeChange',
+        payload: dracoEditor.getModel().createSnapshot().read()
+    });
 });
 
 const outputEditor = monaco.editor.create(document.getElementById('output-viewer'), {
@@ -132,16 +124,48 @@ const outputEditor = monaco.editor.create(document.getElementById('output-viewer
     readOnly: true
 });
 
+worker.onmessage = (ev) => {
+    const msg = ev.data as {
+        type: string;
+        message: string;
+    };
+    switch (msg.type) {
+    case 'setOutputText':
+        outputEditor.getModel().setValue(msg.message);
+        break;
+    default:
+        break;
+    }
+};
+
+
 async function main() {
-    Blazor.start().then( // Start blazor, nonblocking.
-        () => {
-            DotNet.invokeMethodAsync<void>(
-                'Draco.Editor.Web',
-                'OnInit',
-                outputTypeSelector.value, dracoEditor.getModel().createSnapshot().read()
-            );
+    const cfg = await (await fetch('_framework/blazor.boot.json')).json();
+    const dlls = Object.keys(cfg.resources.assembly).map(
+        s => {
+            return {
+                'behavior': 'assembly',
+                'name': s
+            };
         }
     );
+    dlls.push({
+        'behavior': 'dotnetwasm',
+        'name': 'dotnet.wasm'
+    });
+    const bootCfg = {
+        mainAssemblyName: cfg.entryAssembly,
+        assemblyRootFolder: '_framework',
+        assets: dlls,
+    };
+    worker.postMessage(bootCfg);
+    worker.postMessage({
+        type: 'OnInit',
+        payload: {
+            OutputType: outputTypeSelector.value,
+            Code: dracoEditor.getModel().createSnapshot().read()
+        }
+    });
     const wasmPromise = loadWASM(onigasmWasm.buffer); // https://www.npmjs.com/package/onigasm;
 
     const choosenTheme = window.localStorage.getItem('theme'); // get previous user theme choice

--- a/src/Draco.Editor.Web/app/ts/app.ts
+++ b/src/Draco.Editor.Web/app/ts/app.ts
@@ -137,7 +137,6 @@ worker.onmessage = (ev) => {
     }
 };
 
-
 async function main() {
     const cfg = await (await fetch('_framework/blazor.boot.json')).json();
     const dlls = Object.keys(cfg.resources.assembly).map(

--- a/src/Draco.Editor.Web/app/ts/app.ts
+++ b/src/Draco.Editor.Web/app/ts/app.ts
@@ -5,7 +5,6 @@ import { Registry } from 'monaco-textmate';
 import { wireTmGrammars } from 'monaco-editor-textmate'; // Library that allow running Textmates grammar in monaco.
 import grammarDefinition from '../../../Draco.SyntaxHighlighting/draco.tmLanguage.json';
 import { deflateRaw, inflateRaw } from 'pako';
-import { IWorkerMessage } from './workerMessage.js';
 
 // This file is run on page load.
 // This run before blazor load, and will tell blazor to start.
@@ -100,7 +99,7 @@ outputTypeSelector.onchange = () => {
     // We relay the output type change to C#.
     worker.postMessage({
         type: 'OnOutputTypeChange',
-        paylod: newVal
+        payload: newVal
     });
 };
 

--- a/src/Draco.Editor.Web/app/ts/app.ts
+++ b/src/Draco.Editor.Web/app/ts/app.ts
@@ -9,7 +9,7 @@ import { deflateRaw, inflateRaw } from 'pako';
 // This file is run on page load.
 // This run before blazor load, and will tell blazor to start.
 
-const worker = new Worker('worker.js'); // first thing: we start the worker so it load in parallel.
+const worker = new Worker('worker.js'); // first thing: we start the worker so it loads in parallel.
 
 self.MonacoEnvironment = {
     // Web Workers need to start a new script, by url.

--- a/src/Draco.Editor.Web/app/ts/worker.ts
+++ b/src/Draco.Editor.Web/app/ts/worker.ts
@@ -1,5 +1,5 @@
 importScripts('./dotnet.js');
-declare global { // Blazor do not provide types, so we have our own to please typescript.
+declare global { // Blazor does not provide types, so we have our own to please typescript.
     interface Window {
         dotnet: any;
     }

--- a/src/Draco.Editor.Web/app/ts/worker.ts
+++ b/src/Draco.Editor.Web/app/ts/worker.ts
@@ -1,0 +1,77 @@
+importScripts('./dotnet.js');
+declare global { // Blazor do not provide types, so we have our own to please typescript.
+    interface Window {
+        dotnet: any;
+    }
+}
+
+
+let firstMessageResolve;
+let firstMessagePromise = new Promise(
+    resolve => firstMessageResolve = resolve
+);
+
+let initResolve;
+let initPromise = new Promise(
+    resolve => initResolve = resolve
+);
+
+let csOnMessage;
+
+onmessage = async (e: MessageEvent<unknown>) => {
+    if (firstMessageResolve != undefined) {
+        firstMessageResolve(e.data);
+        firstMessageResolve = undefined;
+        return;
+    }
+    if (initPromise != undefined) {
+        await initPromise;
+        initPromise = undefined;
+        initResolve = undefined;
+    }
+    try {
+        csOnMessage(e.data['type'], JSON.stringify(e.data['payload']));
+    } catch (e) {
+        console.log(e);
+        throw e;
+    }
+
+};
+
+function sendMessage(type: string, message: string) {
+    console.log(type);
+    console.log(message);
+    postMessage({
+        type: type,
+        message: message
+    });
+}
+
+async function main() {
+    console.log('Worker starting...');
+    const monoCfg = await firstMessagePromise;
+    console.log('Received boot config.');
+    console.log(monoCfg);
+    firstMessagePromise = undefined;
+    const dotnet = self.dotnet.dotnet;
+    dotnet.moduleConfig.configSrc = null;
+    const { setModuleImports, getAssemblyExports, } = await dotnet
+        .withDiagnosticTracing(true)
+        .withConfig(
+            monoCfg
+        )
+        .create();
+    setModuleImports(
+        'worker.js',
+        {
+            Interop: {
+                sendMessage
+            }
+        }
+    );
+    const exports = await getAssemblyExports(monoCfg['mainAssemblyName']);
+    csOnMessage = exports.Draco.Editor.Web.Interop.OnMessage;
+    initResolve();
+    await dotnet.run();
+}
+main();


### PR DESCRIPTION
This is the first iteration towards having the user program run in a separated process.  
While this doesn't achieve it, the entier toolchain is now in a webworker, which mean a separated process.  
Typing should no longer freeze the whole interface.
The worker JS code is fully reusable without any change so there shouldn't be more difficulties due to the JS ecosystem...