### PR TITLE
Fixed project path duplicating if there's spaces.

### DIFF
--- a/src/Draco.Compiler.Tasks/DracoCompiler.cs
+++ b/src/Draco.Compiler.Tasks/DracoCompiler.cs
@@ -51,6 +51,7 @@ public sealed class DracoCompiler : ToolTask
 
     protected override string GenerateResponseFileCommands()
     {
+        this.ProjectDirectory = "\"" + this.ProjectDirectory + "\"";
         var sb = new StringBuilder($"compile");
         sb.AppendLine();
 


### PR DESCRIPTION
I just added double quote on the directory, so the spaces would still be a valid path.