### PR TITLE
Improved github login in webeditor build script

### DIFF
--- a/src/Draco.Editor.Web/app/build.js
+++ b/src/Draco.Editor.Web/app/build.js
@@ -1,4 +1,4 @@
-import { createActionAuth } from '@octokit/auth-action';
+import { createTokenAuth } from '@octokit/auth-token';
 import { build } from 'esbuild';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -114,15 +114,16 @@ fs.writeFileSync(path.join(outDir, 'favicon.svg'), favicon); // Write favicon to
 console.log('Downloading vs themes...');
 
 let octokit;
-if (process.env.GITHUB_TOKEN != undefined && process.env.GITHUB_TOKEN.length > 0) {
-    const auth = createActionAuth();
+if (process.env.GITHUB_TOKEN !== undefined && process.env.GITHUB_TOKEN.length > 0) {
+    const auth = createTokenAuth(process.env.GITHUB_TOKEN);
     const authentication = await auth();
     octokit = new Octokit({
-        auth: authentication.token
+        auth: authentication.token,
     });
 } else {
     octokit = new Octokit();
 }
+
 
 const response = await octokit.repos.getContent({
     owner: 'microsoft',

--- a/src/Draco.Editor.Web/app/package-lock.json
+++ b/src/Draco.Editor.Web/app/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@octokit/auth-action": "^2.0.2",
+        "@octokit/auth-token": "^4.0.0",
         "buffer": "^6.0.3",
         "fs-extra": "^11.1.0",
         "golden-layout": "^2.6.0",
@@ -202,27 +202,12 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@octokit/auth-action": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-2.0.2.tgz",
-      "integrity": "sha512-uxYIO3eX7moMRr01jaLmfWAuj53cWPzF154yrqDkqySSrUmT0slQYx3uvDs5YC5twl3eeJYZaD5UQhl/8r5mWA==",
-      "dependencies": {
-        "@octokit/auth-token": "^3.0.0",
-        "@octokit/types": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/@octokit/auth-token": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.2.tgz",
-      "integrity": "sha512-pq7CwIMV1kmzkFTimdwjAINCXKTajZErLB4wMLYapR2nuB/Jpr66+05wOTZMSCBXP6n4DdDWT2W19Bm17vU69Q==",
-      "dependencies": {
-        "@octokit/types": "^8.0.0"
-      },
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/core": {
@@ -239,6 +224,15 @@
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
       },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/auth-token": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -274,7 +268,8 @@
     "node_modules/@octokit/openapi-types": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
-      "integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw=="
+      "integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw==",
+      "dev": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "5.0.1",
@@ -366,6 +361,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
       "integrity": "sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==",
+      "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^14.0.0"
       }
@@ -3069,22 +3065,10 @@
         "fastq": "^1.6.0"
       }
     },
-    "@octokit/auth-action": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-2.0.2.tgz",
-      "integrity": "sha512-uxYIO3eX7moMRr01jaLmfWAuj53cWPzF154yrqDkqySSrUmT0slQYx3uvDs5YC5twl3eeJYZaD5UQhl/8r5mWA==",
-      "requires": {
-        "@octokit/auth-token": "^3.0.0",
-        "@octokit/types": "^8.0.0"
-      }
-    },
     "@octokit/auth-token": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.2.tgz",
-      "integrity": "sha512-pq7CwIMV1kmzkFTimdwjAINCXKTajZErLB4wMLYapR2nuB/Jpr66+05wOTZMSCBXP6n4DdDWT2W19Bm17vU69Q==",
-      "requires": {
-        "@octokit/types": "^8.0.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
     },
     "@octokit/core": {
       "version": "4.1.0",
@@ -3099,6 +3083,14 @@
         "@octokit/types": "^8.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/auth-token": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+          "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+          "dev": true
+        }
       }
     },
     "@octokit/endpoint": {
@@ -3126,7 +3118,8 @@
     "@octokit/openapi-types": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
-      "integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw=="
+      "integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw==",
+      "dev": true
     },
     "@octokit/plugin-paginate-rest": {
       "version": "5.0.1",
@@ -3195,6 +3188,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
       "integrity": "sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==",
+      "dev": true,
       "requires": {
         "@octokit/openapi-types": "^14.0.0"
       }

--- a/src/Draco.Editor.Web/app/package.json
+++ b/src/Draco.Editor.Web/app/package.json
@@ -5,7 +5,7 @@
     "build-release": "tsc -noEmit && node build.js ../bin/Release/net7.0"
   },
   "dependencies": {
-    "@octokit/auth-action": "^2.0.2",
+    "@octokit/auth-token": "^4.0.0",
     "buffer": "^6.0.3",
     "fs-extra": "^11.1.0",
     "golden-layout": "^2.6.0",


### PR DESCRIPTION
Our webeditor build script pulls assets from github to avoid duplicating assets accross repositories.  
GitHub API rate limit is very aggressive, so if you are rebuilding often you to set a github token in the environement variables.  
This fix is simply removing github CI authentification by a regular token authentification.  
The CI authentification libs of github doesn't like not running in CI.
This code is already present in our website build step, I just pasted it to update this one.