### PR TITLE
Script fix for install debugger.

### DIFF
--- a/scripts/install_debugadapter.ps1
+++ b/scripts/install_debugadapter.ps1
@@ -1,6 +1,8 @@
 $ErrorActionPreference = "Stop"
+Push-Location $PSScriptRoot
 dotnet pack ../src/Draco.DebugAdapter --output .
 if ((dotnet tool list --global) -match "Draco.DebugAdapter") {
     dotnet tool uninstall --global Draco.DebugAdapter
 }
 dotnet tool install --global --add-source . Draco.DebugAdapter
+Pop-Location


### PR DESCRIPTION
Turns out all the script had a problem.  
Basically the working directory isn't the script location, but where it's run from.  
