### PR TITLE
Fixed issue 378.

### DIFF
--- a/src/Draco.Compiler.Tests/Semantics/FlowAnalysisTests.cs
+++ b/src/Draco.Compiler.Tests/Semantics/FlowAnalysisTests.cs
@@ -574,7 +574,7 @@ public sealed class FlowAnalysisTests : SemanticTestsBase
     }
 
     [Fact]
-    public void Issue378()
+    public void MultipleIndexerAssignationInfersType()
     {
         //func main()
         //{

--- a/src/Draco.Compiler/Internal/Solver/ConstraintSolver_Rules.cs
+++ b/src/Draco.Compiler/Internal/Solver/ConstraintSolver_Rules.cs
@@ -64,7 +64,7 @@ internal sealed partial class ConstraintSolver
             var assignmentsWithSameTarget = this
                 .Enumerate<AssignableConstraint>(a => SymbolEqualityComparer.AllowTypeVariables.Equals(assignable.TargetType, a.TargetType))
                 .ToList();
-            if (assignmentsWithSameTarget.Count == 0)
+            if (assignmentsWithSameTarget.Count == 0 || assignable.TargetType.IsGroundType)
             {
                 // No, assume same type
                 UnifyAsserted(assignable.TargetType, assignable.AssignedType);

--- a/src/Draco.Compiler/Internal/Solver/ConstraintSolver_Rules.cs
+++ b/src/Draco.Compiler/Internal/Solver/ConstraintSolver_Rules.cs
@@ -64,7 +64,7 @@ internal sealed partial class ConstraintSolver
             var assignmentsWithSameTarget = this
                 .Enumerate<AssignableConstraint>(a => SymbolEqualityComparer.AllowTypeVariables.Equals(assignable.TargetType, a.TargetType))
                 .ToList();
-            if (assignmentsWithSameTarget.Count == 0 )
+            if (assignmentsWithSameTarget.Count == 0 || assignable.TargetType.IsGroundType)
             {
                 // No, assume same type
                 UnifyAsserted(assignable.TargetType, assignable.AssignedType);
@@ -97,11 +97,11 @@ internal sealed partial class ConstraintSolver
             var commonNonTypeVars = common2.AlternativeTypes
                 .Where(t => !t.Substitution.IsTypeVariable)
                 .ToImmutableHashSet(SymbolEqualityComparer.AllowTypeVariables);
-            if (commonNonTypeVars.Count != 1 && !common2.CommonType.IsGroundType) continue;
+            if (commonNonTypeVars.Count != 1) continue;
 
             // NOTE: We do NOT remove the constraint, will be resolved in a future iteration
             // Only one non-type-var, the rest are type variables
-            var nonTypeVar = commonNonTypeVars.SingleOrDefault() ?? common2.CommonType;
+            var nonTypeVar = commonNonTypeVars.Single();
             foreach (var tv in commonTypeVars) UnifyAsserted(tv, nonTypeVar);
             return true;
         }

--- a/src/Draco.Compiler/Internal/Solver/ConstraintSolver_Rules.cs
+++ b/src/Draco.Compiler/Internal/Solver/ConstraintSolver_Rules.cs
@@ -64,7 +64,7 @@ internal sealed partial class ConstraintSolver
             var assignmentsWithSameTarget = this
                 .Enumerate<AssignableConstraint>(a => SymbolEqualityComparer.AllowTypeVariables.Equals(assignable.TargetType, a.TargetType))
                 .ToList();
-            if (assignmentsWithSameTarget.Count == 0 || assignable.TargetType.IsGroundType)
+            if (assignmentsWithSameTarget.Count == 0 )
             {
                 // No, assume same type
                 UnifyAsserted(assignable.TargetType, assignable.AssignedType);
@@ -97,11 +97,11 @@ internal sealed partial class ConstraintSolver
             var commonNonTypeVars = common2.AlternativeTypes
                 .Where(t => !t.Substitution.IsTypeVariable)
                 .ToImmutableHashSet(SymbolEqualityComparer.AllowTypeVariables);
-            if (commonNonTypeVars.Count != 1) continue;
+            if (commonNonTypeVars.Count != 1 && !common2.CommonType.IsGroundType) continue;
 
             // NOTE: We do NOT remove the constraint, will be resolved in a future iteration
             // Only one non-type-var, the rest are type variables
-            var nonTypeVar = commonNonTypeVars.Single();
+            var nonTypeVar = commonNonTypeVars.SingleOrDefault() ?? common2.CommonType;
             foreach (var tv in commonTypeVars) UnifyAsserted(tv, nonTypeVar);
             return true;
         }


### PR DESCRIPTION
Fixes #378.
The root problem is there is multiple `AssignableConstraint` with `Assign(bool, SomeType)`.
Theses types get lumped together as a CommonType, and the solver is unable to resolve.  

Tbh I'm really unsure of my fix.
