### PR TITLE
Bug/issue 398

### DIFF
--- a/src/Draco.Compiler.Tests/EndToEnd/CompilingCodeTests.cs
+++ b/src/Draco.Compiler.Tests/EndToEnd/CompilingCodeTests.cs
@@ -683,4 +683,15 @@ public sealed class CompilingCodeTests : EndToEndTestsBase
         var x = Invoke<string>(assembly, "stringify", 123);
         Assert.Equal("123", x);
     }
+
+    [Fact]
+    public void PlusIntegerCompiles()
+    {
+        var assembly = Compile("""
+            public func zero(): int32 = +0;
+            """);
+
+        var x = Invoke<int>(assembly, "zero");
+        Assert.Equal(0, x);
+    }
 }

--- a/src/Draco.Compiler/Internal/OptimizingIr/FunctionBodyCodegen.cs
+++ b/src/Draco.Compiler/Internal/OptimizingIr/FunctionBodyCodegen.cs
@@ -276,7 +276,6 @@ internal sealed partial class FunctionBodyCodegen : BoundTreeVisitor<IOperand>
             .Zip(node.Method.Parameters)
             .Select(pair => this.BoxIfNeeded(pair.Second.Type, this.Compile(pair.First)))
             .ToImmutableArray();
-        var callResult = this.DefineRegister(node.TypeRequired);
 
         var proc = this.TranslateFunctionSymbol(node.Method);
         if (proc.Codegen is { } codegen)
@@ -285,10 +284,11 @@ internal sealed partial class FunctionBodyCodegen : BoundTreeVisitor<IOperand>
             {
                 throw new System.NotImplementedException();
             }
-            codegen(this, callResult, args);
+            return codegen(this, node.TypeRequired, args);
         }
         else
         {
+            var callResult = this.DefineRegister(node.TypeRequired);
             if (receiver is null)
             {
                 this.Write(Call(callResult, proc, args));
@@ -297,8 +297,8 @@ internal sealed partial class FunctionBodyCodegen : BoundTreeVisitor<IOperand>
             {
                 this.Write(MemberCall(callResult, proc, receiver, args));
             }
+            return callResult;
         }
-        return callResult;
     }
 
     private IOperand? CompileReceiver(BoundCallExpression call)
@@ -396,14 +396,12 @@ internal sealed partial class FunctionBodyCodegen : BoundTreeVisitor<IOperand>
         if (node.CompoundOperator is not null)
         {
             var leftValue = this.DefineRegister(node.Left.Type);
-            var tmp = this.DefineRegister(node.TypeRequired);
-            toStore = tmp;
             // Patch
             PatchLoadTarget(leftLoad, leftValue);
             this.Write(leftLoad);
             if (node.CompoundOperator.Codegen is { } codegen)
             {
-                codegen(this, tmp, ImmutableArray.Create(leftValue, right));
+                toStore = codegen(this, node.TypeRequired, ImmutableArray.Create(leftValue, right));
             }
             else
             {

--- a/src/Draco.Compiler/Internal/Symbols/FunctionSymbol.cs
+++ b/src/Draco.Compiler/Internal/Symbols/FunctionSymbol.cs
@@ -19,11 +19,12 @@ internal abstract partial class FunctionSymbol : Symbol, ITypedSymbol, IMemberSy
     /// A delegate to generate IR code.
     /// </summary>
     /// <param name="codegen">The code generator.</param>
-    /// <param name="target">The register to store the result at.</param>
+    /// <param name="targetType">The target type of the resulting value.</param>
     /// <param name="operands">The compiled operand references.</param>
-    public delegate void CodegenDelegate(
+    /// <returns>The operand that holds the result of the operation.</returns>
+    public delegate IOperand CodegenDelegate(
         FunctionBodyCodegen codegen,
-        Register target,
+        TypeSymbol targetType,
         ImmutableArray<IOperand> operands);
 
     /// <summary>

--- a/src/Draco.Compiler/Internal/Symbols/Synthetized/ArrayConstructorSymbol.cs
+++ b/src/Draco.Compiler/Internal/Symbols/Synthetized/ArrayConstructorSymbol.cs
@@ -38,10 +38,12 @@ internal sealed class ArrayConstructorSymbol : FunctionSymbol
         LazyInitializer.EnsureInitialized(ref this.elementType, this.BuildElementType);
     private TypeParameterSymbol? elementType;
 
-    public override CodegenDelegate Codegen => (codegen, target, operands) =>
+    public override CodegenDelegate Codegen => (codegen, targetType, operands) =>
     {
-        var elementType = target.Type.Substitution.GenericArguments[0];
+        var target = codegen.DefineRegister(targetType);
+        var elementType = targetType.Substitution.GenericArguments[0];
         codegen.Write(NewArray(target, elementType, operands));
+        return target;
     };
 
     private readonly ArrayTypeSymbol genericArrayType;

--- a/src/Draco.Compiler/Internal/Symbols/Synthetized/ConstructorFunctionSymbol.cs
+++ b/src/Draco.Compiler/Internal/Symbols/Synthetized/ConstructorFunctionSymbol.cs
@@ -29,15 +29,16 @@ internal sealed class ConstructorFunctionSymbol : FunctionSymbol
     private FunctionSymbol ConstructorSymbol => LazyInitializer.EnsureInitialized(ref this.constructorSymbol, this.BuildConstructorSymbol);
     private FunctionSymbol? constructorSymbol;
 
-    public override CodegenDelegate Codegen => (codegen, target, args) =>
+    public override CodegenDelegate Codegen => (codegen, targetType, args) =>
     {
-        var instance = target.Type;
+        var target = codegen.DefineRegister(targetType);
         var ctorSymbol = this.ConstructorSymbol;
-        if (instance.IsGenericInstance && this.IsGenericDefinition)
+        if (targetType.IsGenericInstance && this.IsGenericDefinition)
         {
-            ctorSymbol = ctorSymbol.GenericInstantiate(instance, ((IGenericInstanceSymbol)instance).Context);
+            ctorSymbol = ctorSymbol.GenericInstantiate(targetType, ((IGenericInstanceSymbol)targetType).Context);
         }
         codegen.Write(NewObject(target, ctorSymbol, args));
+        return target;
     };
 
     private GenericContext? Context


### PR DESCRIPTION
Fixes #398 

Essentially moves the responsibility of allocating registers to the intrinsic methods themselves. This means, that for things like `+x`, the codegen can just skip this step and simply return its operand.