### PR TITLE
C heritage tokens

### DIFF
--- a/src/Draco.Compiler.Tests/Syntax/LexerTests.cs
+++ b/src/Draco.Compiler.Tests/Syntax/LexerTests.cs
@@ -1156,6 +1156,10 @@ public sealed class LexerTests
     [InlineData("rem", TokenKind.KeywordRem)]
     [InlineData("and", TokenKind.KeywordAnd)]
     [InlineData("not", TokenKind.KeywordNot)]
+    [InlineData("%", TokenKind.CMod)]
+    [InlineData("||", TokenKind.COr)]
+    [InlineData("&&", TokenKind.CAnd)]
+    [InlineData("!", TokenKind.CNot)]
     [Trait("Feature", "Operators")]
     public void TestOperator(string text, TokenKind tokenKind)
     {

--- a/src/Draco.Compiler.Tests/Syntax/ParserTests.cs
+++ b/src/Draco.Compiler.Tests/Syntax/ParserTests.cs
@@ -1445,7 +1445,7 @@ public sealed class ParserTests
             {
                 this.T(TokenKind.LiteralInteger, "3");
             }
-            this.InvalidT(TokenKind.CMod, SyntaxErrors.CHertiageToken);
+            this.InvalidT(TokenKind.CMod, SyntaxErrors.CHeritageToken);
             this.N<LiteralExpressionSyntax>();
             {
                 this.T(TokenKind.LiteralInteger, "2");
@@ -1501,16 +1501,16 @@ public sealed class ParserTests
                 {
                     this.T(TokenKind.KeywordTrue);
                 }
-                this.InvalidT(TokenKind.CAnd, SyntaxErrors.CHertiageToken);
+                this.InvalidT(TokenKind.CAnd, SyntaxErrors.CHeritageToken);
                 this.N<LiteralExpressionSyntax>();
                 {
                     this.T(TokenKind.KeywordFalse);
                 }
             }
-            this.InvalidT(TokenKind.COr, SyntaxErrors.CHertiageToken);
+            this.InvalidT(TokenKind.COr, SyntaxErrors.CHeritageToken);
             this.N<UnaryExpressionSyntax>();
             {
-                this.InvalidT(TokenKind.CNot, SyntaxErrors.CHertiageToken);
+                this.InvalidT(TokenKind.CNot, SyntaxErrors.CHeritageToken);
                 this.N<LiteralExpressionSyntax>();
                 {
                     this.T(TokenKind.KeywordFalse);

--- a/src/Draco.Compiler/Api/Syntax/SyntaxFacts.cs
+++ b/src/Draco.Compiler/Api/Syntax/SyntaxFacts.cs
@@ -65,6 +65,10 @@ public static class SyntaxFacts
         TokenKind.StarAssign => "*=",
         TokenKind.SlashAssign => "/=",
         TokenKind.Ellipsis => "...",
+        TokenKind.CMod => "%",
+        TokenKind.COr => "||",
+        TokenKind.CAnd => "&&",
+        TokenKind.CNot => "!",
         _ => null,
     };
 
@@ -137,6 +141,20 @@ public static class SyntaxFacts
     /// <returns>True, if <paramref name="tokenKind"/> is a keyword, false otherwise.</returns>
     public static bool IsKeyword(TokenKind tokenKind) =>
         tokenKind.ToString().StartsWith("Keyword");
+
+    /// <summary>
+    /// Returns the replacement token for a given C-heritage token.
+    /// </summary>
+    /// <param name="tokenKind">The <see cref="TokenKind"/> of the heritage token.</param>
+    /// <returns>The syntactically valid token which replaces the <paramref name="tokenKind"/> heritage token, or null if <paramref name="tokenKind"/> is not a heritage token.</returns>
+    public static TokenKind? GetHeritageReplacement(TokenKind tokenKind) => tokenKind switch
+    {
+        TokenKind.CMod => TokenKind.KeywordMod,
+        TokenKind.COr => TokenKind.KeywordOr,
+        TokenKind.CAnd => TokenKind.KeywordAnd,
+        TokenKind.CNot => TokenKind.KeywordNot,
+        _ => null
+    };
 
     /// <summary>
     /// Computes the cutoff sequence that is removed from each line of a multiline string.

--- a/src/Draco.Compiler/Api/Syntax/TokenKind.cs
+++ b/src/Draco.Compiler/Api/Syntax/TokenKind.cs
@@ -314,4 +314,24 @@ public enum TokenKind
     /// '...'.
     /// </summary>
     Ellipsis,
+
+    /// <summary>
+    /// '%' (C-heritage).
+    /// </summary>
+    CMod,
+
+    /// <summary>
+    /// '||' (C-heritage).
+    /// </summary>
+    COr,
+
+    /// <summary>
+    /// '&amp;&amp;' (C-heritage).
+    /// </summary>
+    CAnd,
+
+    /// <summary>
+    /// '!' (C-heritage).
+    /// </summary>
+    CNot
 }

--- a/src/Draco.Compiler/Internal/Binding/Binder_Expression.cs
+++ b/src/Draco.Compiler/Internal/Binding/Binder_Expression.cs
@@ -443,7 +443,7 @@ internal partial class Binder
                 return new BoundAssignmentExpression(syntax, null, left, await rightTask);
             }
         }
-        else if (syntax.Operator.Kind is TokenKind.KeywordAnd or TokenKind.KeywordOr)
+        else if (syntax.Operator.Kind is TokenKind.KeywordAnd or TokenKind.KeywordOr or TokenKind.CAnd or TokenKind.COr)
         {
             var leftTask = this.BindExpression(syntax.Left, constraints, diagnostics);
             var rightTask = this.BindExpression(syntax.Right, constraints, diagnostics);
@@ -458,7 +458,7 @@ internal partial class Binder
                 rightTask.GetResultType(syntax.Left, constraints, diagnostics),
                 syntax.Right);
 
-            return syntax.Operator.Kind == TokenKind.KeywordAnd
+            return syntax.Operator.Kind is TokenKind.KeywordAnd or TokenKind.CAnd
                 ? new BoundAndExpression(syntax, await leftTask, await rightTask)
                 : new BoundOrExpression(syntax, await leftTask, await rightTask);
         }

--- a/src/Draco.Compiler/Internal/Symbols/FunctionSymbol.cs
+++ b/src/Draco.Compiler/Internal/Symbols/FunctionSymbol.cs
@@ -36,7 +36,7 @@ internal abstract partial class FunctionSymbol : Symbol, ITypedSymbol, IMemberSy
     {
         TokenKind.Plus => "op_UnaryPlus",
         TokenKind.Minus => "op_UnaryNegation",
-        TokenKind.KeywordNot => "op_LogicalNot",
+        TokenKind.KeywordNot or TokenKind.CNot => "op_LogicalNot",
         _ => throw new System.ArgumentOutOfRangeException(nameof(token)),
     };
 
@@ -54,7 +54,7 @@ internal abstract partial class FunctionSymbol : Symbol, ITypedSymbol, IMemberSy
         // NOTE: This is actually remainder
         TokenKind.KeywordRem => "op_Modulus",
         // TODO: Consider for interop
-        TokenKind.KeywordMod => "op_DracoModulo",
+        TokenKind.KeywordMod or TokenKind.CMod => "op_DracoModulo",
         _ => throw new System.ArgumentOutOfRangeException(nameof(token)),
     };
 

--- a/src/Draco.Compiler/Internal/Syntax/Lexer.cs
+++ b/src/Draco.Compiler/Internal/Syntax/Lexer.cs
@@ -237,7 +237,13 @@ internal sealed class Lexer
             return TakeBasic(TokenKind.Assign, 1);
         case '!':
             if (this.Peek(1) == '=') return TakeBasic(TokenKind.NotEqual, 2);
-            // NOTE: '!' in it self is not negation!
+            return TakeBasic(TokenKind.CNot, 1);
+        case '%': return TakeBasic(TokenKind.CMod, 1);
+        case '|':
+            if (this.Peek(1) == '|') return TakeBasic(TokenKind.COr, 2);
+            break;
+        case '&':
+            if (this.Peek(1) == '&') return TakeBasic(TokenKind.CAnd, 2);
             break;
         }
 

--- a/src/Draco.Compiler/Internal/Syntax/Parser.cs
+++ b/src/Draco.Compiler/Internal/Syntax/Parser.cs
@@ -119,7 +119,7 @@ internal sealed class Parser(
             // Check if the operator is a C-heritage operator
             if (SyntaxFacts.GetHeritageReplacement(op.Kind) is { } replacementKind)
             {
-                var info = DiagnosticInfo.Create(SyntaxErrors.CHertiageSymbol, SyntaxFacts.GetUserFriendlyName(op.Kind), SyntaxFacts.GetUserFriendlyName(replacementKind));
+                var info = DiagnosticInfo.Create(SyntaxErrors.CHertiageToken, "operator", SyntaxFacts.GetUserFriendlyName(op.Kind), SyntaxFacts.GetUserFriendlyName(replacementKind));
                 var diag = new SyntaxDiagnosticInfo(info, Offset: 0, Width: op.Width);
                 this.AddDiagnostic(op, diag);
             }
@@ -153,7 +153,7 @@ internal sealed class Parser(
             // Check if the operator is a C-heritage operator
             if (SyntaxFacts.GetHeritageReplacement(op.Kind) is { } replacementKind)
             {
-                var info = DiagnosticInfo.Create(SyntaxErrors.CHertiageSymbol, SyntaxFacts.GetUserFriendlyName(op.Kind), SyntaxFacts.GetUserFriendlyName(replacementKind));
+                var info = DiagnosticInfo.Create(SyntaxErrors.CHertiageToken, "operator", SyntaxFacts.GetUserFriendlyName(op.Kind), SyntaxFacts.GetUserFriendlyName(replacementKind));
                 var diag = new SyntaxDiagnosticInfo(info, Offset: 0, Width: op.Width);
                 this.AddDiagnostic(op, diag);
             }

--- a/src/Draco.Compiler/Internal/Syntax/Parser.cs
+++ b/src/Draco.Compiler/Internal/Syntax/Parser.cs
@@ -119,7 +119,7 @@ internal sealed class Parser(
             // Check if the operator is a C-heritage operator
             if (SyntaxFacts.GetHeritageReplacement(op.Kind) is { } replacementKind)
             {
-                var info = DiagnosticInfo.Create(SyntaxErrors.CHertiageToken, "operator", SyntaxFacts.GetUserFriendlyName(op.Kind), SyntaxFacts.GetUserFriendlyName(replacementKind));
+                var info = DiagnosticInfo.Create(SyntaxErrors.CHertiageToken, SyntaxFacts.GetUserFriendlyName(op.Kind), "operator", SyntaxFacts.GetUserFriendlyName(replacementKind));
                 var diag = new SyntaxDiagnosticInfo(info, Offset: 0, Width: op.Width);
                 this.AddDiagnostic(op, diag);
             }
@@ -153,7 +153,7 @@ internal sealed class Parser(
             // Check if the operator is a C-heritage operator
             if (SyntaxFacts.GetHeritageReplacement(op.Kind) is { } replacementKind)
             {
-                var info = DiagnosticInfo.Create(SyntaxErrors.CHertiageToken, "operator", SyntaxFacts.GetUserFriendlyName(op.Kind), SyntaxFacts.GetUserFriendlyName(replacementKind));
+                var info = DiagnosticInfo.Create(SyntaxErrors.CHertiageToken, SyntaxFacts.GetUserFriendlyName(op.Kind), "operator", SyntaxFacts.GetUserFriendlyName(replacementKind));
                 var diag = new SyntaxDiagnosticInfo(info, Offset: 0, Width: op.Width);
                 this.AddDiagnostic(op, diag);
             }

--- a/src/Draco.Compiler/Internal/Syntax/Parser.cs
+++ b/src/Draco.Compiler/Internal/Syntax/Parser.cs
@@ -1418,7 +1418,7 @@ internal sealed class Parser(
     /// <param name="syntaxKind">The text which is displayed in the reported diagnostic indicating what kind of syntactic element the heritage token is.</param>
     private void CheckHeritageToken(SyntaxToken token, string syntaxKind)
     {
-        if (!(SyntaxFacts.GetHeritageReplacement(token.Kind) is { } replacementKind)) return;
+        if (SyntaxFacts.GetHeritageReplacement(token.Kind) is not { } replacementKind) return;
 
         var info = DiagnosticInfo.Create(SyntaxErrors.CHeritageToken, SyntaxFacts.GetUserFriendlyName(token.Kind), syntaxKind, SyntaxFacts.GetUserFriendlyName(replacementKind));
         var diag = new SyntaxDiagnosticInfo(info, Offset: 0, Width: token.Width);

--- a/src/Draco.Compiler/Internal/Syntax/Parser.cs
+++ b/src/Draco.Compiler/Internal/Syntax/Parser.cs
@@ -1418,12 +1418,11 @@ internal sealed class Parser(
     /// <param name="syntaxKind">The text which is displayed in the reported diagnostic indicating what kind of syntactic element the heritage token is.</param>
     private void CheckHeritageToken(SyntaxToken token, string syntaxKind)
     {
-        if (SyntaxFacts.GetHeritageReplacement(token.Kind) is { } replacementKind)
-        {
-            var info = DiagnosticInfo.Create(SyntaxErrors.CHertiageToken, SyntaxFacts.GetUserFriendlyName(token.Kind), syntaxKind, SyntaxFacts.GetUserFriendlyName(replacementKind));
-            var diag = new SyntaxDiagnosticInfo(info, Offset: 0, Width: token.Width);
-            this.AddDiagnostic(token, diag);
-        }
+        if (!(SyntaxFacts.GetHeritageReplacement(token.Kind) is { } replacementKind)) return;
+
+        var info = DiagnosticInfo.Create(SyntaxErrors.CHeritageToken, SyntaxFacts.GetUserFriendlyName(token.Kind), syntaxKind, SyntaxFacts.GetUserFriendlyName(replacementKind));
+        var diag = new SyntaxDiagnosticInfo(info, Offset: 0, Width: token.Width);
+        this.AddDiagnostic(token, diag);
     }
 
     // Token-level operators

--- a/src/Draco.Compiler/Internal/Syntax/Syntax.xml
+++ b/src/Draco.Compiler/Internal/Syntax/Syntax.xml
@@ -1046,6 +1046,7 @@
       <Token Kind="Plus" />
       <Token Kind="Minus" />
       <Token Kind="KeywordNot" />
+      <Token Kind="CNot" />
     </Field>
     <Field Name="Operand" Type="ExpressionSyntax">
       <Documentation>
@@ -1082,6 +1083,9 @@
       <Token Kind="KeywordRem" />
       <Token Kind="KeywordAnd" />
       <Token Kind="KeywordOr" />
+      <Token Kind="CMod"/>
+      <Token Kind="COr"/>
+      <Token Kind="CAnd"/>
     </Field>
     <Field Name="Right" Type="ExpressionSyntax">
       <Documentation>

--- a/src/Draco.Compiler/Internal/Syntax/SyntaxErrors.cs
+++ b/src/Draco.Compiler/Internal/Syntax/SyntaxErrors.cs
@@ -157,9 +157,9 @@ internal static class SyntaxErrors
     /// <summary>
     /// A C-heritage symbol is used instead of the appropriate keyword.
     /// </summary>
-    public static readonly DiagnosticTemplate CHertiageSymbol = DiagnosticTemplate.Create(
+    public static readonly DiagnosticTemplate CHertiageToken = DiagnosticTemplate.Create(
         title: "C heritage symbol",
         severity: DiagnosticSeverity.Error,
-        format: "{0} is not used by Draco, use {1} instead",
+        format: "{0} is not a valid {1} in Draco, use {2} instead",
         code: Code(17));
 }

--- a/src/Draco.Compiler/Internal/Syntax/SyntaxErrors.cs
+++ b/src/Draco.Compiler/Internal/Syntax/SyntaxErrors.cs
@@ -157,7 +157,7 @@ internal static class SyntaxErrors
     /// <summary>
     /// A C-heritage symbol is used instead of the appropriate keyword.
     /// </summary>
-    public static readonly DiagnosticTemplate CHertiageToken = DiagnosticTemplate.Create(
+    public static readonly DiagnosticTemplate CHeritageToken = DiagnosticTemplate.Create(
         title: "C heritage symbol",
         severity: DiagnosticSeverity.Error,
         format: "{0} is not a valid {1} in Draco, use {2} instead",

--- a/src/Draco.Compiler/Internal/Syntax/SyntaxErrors.cs
+++ b/src/Draco.Compiler/Internal/Syntax/SyntaxErrors.cs
@@ -153,4 +153,13 @@ internal static class SyntaxErrors
         severity: DiagnosticSeverity.Error,
         format: "unexpected {0} before import statement",
         code: Code(16));
+
+    /// <summary>
+    /// A C-heritage symbol is used instead of the appropriate keyword.
+    /// </summary>
+    public static readonly DiagnosticTemplate CHertiageSymbol = DiagnosticTemplate.Create(
+        title: "C heritage symbol",
+        severity: DiagnosticSeverity.Error,
+        format: "{0} is not used by Draco, use {1} instead",
+        code: Code(17));
 }


### PR DESCRIPTION
Fix #324.

Currently supports:
- `%` -> `mod`
- `||` -> `or`
- `&&` -> `and`
- `!` -> `not`

Todo: write tests. Also want feedback on the names of the tokens (`CMod`, etc.) and the `CHertiageSymbol` syntax diagnostic.