### PR TITLE
Add EmitCompilerGeneratedFiles tag to Directory.Build.Props

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <UseArtifactsOutput>true</UseArtifactsOutput>
+    <EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <!-- Package metadata -->


### PR DESCRIPTION
Add `<EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>` to Directory.Build.Props for an easier time enabling emitting compiler generated files. Would be especially useful when using VSCode and working on the source generator.